### PR TITLE
Cancel run action without run id throws forbidden error

### DIFF
--- a/runtime.py
+++ b/runtime.py
@@ -14,7 +14,6 @@ if None in inputs_list:
     
 if RUN_ID == "":
     print("- RUN_ID was not provided.")
-    print("  Deployment was not successfully created.")
     print("  No need to cancel it.")
     exit(0)
 

--- a/runtime.py
+++ b/runtime.py
@@ -8,6 +8,9 @@ RUN_ID = os.getenv("RUN_ID")
 
 inputs_list = [CLIENT_ID, CLIENT_KEY, CLIENT_REALM, RUN_ID]
 
+print("Run Id: ",RUN_ID)
+print("Type", type(RUN_ID))
+
 if None in inputs_list:
     print("- Some mandatory input is empty. Please, check the input list.")
     exit(1)

--- a/runtime.py
+++ b/runtime.py
@@ -6,14 +6,17 @@ CLIENT_KEY = os.getenv("CLIENT_KEY")
 CLIENT_REALM = os.getenv("CLIENT_REALM")
 RUN_ID = os.getenv("RUN_ID")
 
-inputs_list = [CLIENT_ID, CLIENT_KEY, CLIENT_REALM, RUN_ID]
-
-print("Run Id: ",RUN_ID)
-print("Type", type(RUN_ID))
+inputs_list = [CLIENT_ID, CLIENT_KEY, CLIENT_REALM]
 
 if None in inputs_list:
-    print("- Some mandatory input is empty. Please, check the input list.")
+    print("- Some mandatory authentication input is empty. Please, check the input list.")
     exit(1)
+    
+if RUN_ID == "":
+    print("- RUN_ID was not provided.")
+    print("  Deployment was not successfully created.")
+    print("  No need to cancel it.")
+    exit(0)
 
 # Getting access token
 print("Authenticating..")


### PR DESCRIPTION
## Context

When a run is not successfully created the following uri is called `v1/run/cancel/` without the run_id that would be generated.

since this URL does not exists in Manager's API and OPA policy the following error is thrown

```
Authenticating..
Cancelling Run...
- Error cancelling run
- Status: 403
- Error: Forbidden
- Response: 
```

It used to validate via the input_list, although when an output from other pipe is not generated, it is delivered as an empty string. 

This PR changes the validation, and does not throw an error, so its a better user experience.

## Evidences
[Workflow URL](https://github.com/stack-spot/runtimes-cancel-action-validation/actions/runs/7645565721/job/20832535961)
<img width="1784" alt="Captura de Tela 2024-01-24 às 17 10 17" src="https://github.com/stack-spot/runtime-cancel-run-action/assets/149098642/b7335050-7825-4c33-b134-3128bd04aa28">

